### PR TITLE
cassandra-stress: delay before retry

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsErrors.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsErrors.java
@@ -23,8 +23,11 @@ package org.apache.cassandra.stress.settings;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.stress.util.ResultLogger;
 
@@ -36,26 +39,88 @@ public class SettingsErrors implements Serializable
     public final boolean skipReadValidation;
     public final boolean skipUnsupportedColumns;
 
+    private enum DelayPolicy {
+        CONSTANT,
+        LINEAR,
+        EXPONENTIAL
+    }
+    private final DelayPolicy delayPolicy;
+    private final long minDelayMs;
+    private final long maxDelayMs;
+
     public SettingsErrors(Options options)
     {
         ignore = options.ignore.setByUser();
         this.tries = Math.max(1, Integer.parseInt(options.retries.value()) + 1);
         skipReadValidation = options.skipReadValidation.setByUser();
         skipUnsupportedColumns = options.skipUnsupportedColumns.setByUser();
+        delayPolicy = DelayPolicy.valueOf(options.delayPolicy.value().toUpperCase());
+        minDelayMs = Long.parseLong(options.minDelayMs.value());
+        maxDelayMs = Long.parseLong(options.maxDelayMs.value());
+    }
+
+    // Accessor used by stress.Operation
+    public Duration nextDelay(int num_tries) {
+        assert num_tries >= 0;
+        assert num_tries < tries;
+        long delay = minDelayMs;
+        switch (delayPolicy) {
+        case CONSTANT:
+            // wait for constant time between each retry
+            break;
+        case LINEAR:
+            // linearly increase the delay
+            delay += (maxDelayMs - minDelayMs) * (float)num_tries / tries;
+            break;
+        case EXPONENTIAL:
+            // exponentially back off
+            delay *= (1L << num_tries);
+            break;
+        default:
+            throw new AssertionError();
+        }
+        // include some jitter to prevent all sessions to retry at the same
+        // time.
+        double jitter_ratio = ThreadLocalRandom.current().nextDouble(0.75, 1.25);
+        delay *= jitter_ratio;
+        delay = Math.max(delay, minDelayMs);
+        delay = Math.min(delay, maxDelayMs);
+        return Duration.ofMillis(delay);
     }
 
     // Option Declarations
-
     public static final class Options extends GroupedOptions
     {
         final OptionSimple retries = new OptionSimple("retries=", "[0-9]+", "9", "Number of tries to perform for each operation before failing", false);
         final OptionSimple ignore = new OptionSimple("ignore", "", null, "Do not fail on errors", false);
         final OptionSimple skipReadValidation = new OptionSimple("skip-read-validation", "", null, "Skip read validation and message output", false);
         final OptionSimple skipUnsupportedColumns = new OptionSimple("skip-unsupported-columns", "", null, "Skip unsupported columns, such as maps and embedded collections, when generating data for a user profile.", false);
+
+        final OptionSimple delayPolicy = new OptionSimple("delay-policy=", "constant|linear|exponential", "constant", "Delay before next retry: constant, waits a constant time; linear, increases linearly, exponential, double the delay every time", false);
+        final OptionSimple minDelayMs = new OptionSimple("min-delay-ms=", "[0-9]+", "0", "Minimum delay in milliseconds, please use a non-zero value with exponential", false);
+        final OptionSimple maxDelayMs = new OptionSimple("max-delay-ms=", "[0-9]+", "20000", "Maximum delay in milliseconds", false);
+
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(retries, ignore, skipReadValidation, skipUnsupportedColumns);
+            return Arrays.asList(retries, ignore, skipReadValidation, skipUnsupportedColumns,
+                                 delayPolicy, minDelayMs, maxDelayMs);
+        }
+
+        @Override
+        public boolean happy() {
+            if (!super.happy()) {
+                return false;
+            }
+            long minDelay = Long.parseLong(minDelayMs.value());
+            long maxDelay = Long.parseLong(maxDelayMs.value());
+            if (minDelay > maxDelay) {
+                return false;
+            }
+            if (DelayPolicy.valueOf(delayPolicy.value().toUpperCase()) == DelayPolicy.EXPONENTIAL) {
+                return minDelay > 0;
+            }
+            return true;
         }
     }
 
@@ -64,6 +129,14 @@ public class SettingsErrors implements Serializable
     {
         out.printf("  Ignore: %b%n", ignore);
         out.printf("  Tries: %d%n", tries);
+        if (delayPolicy == DelayPolicy.CONSTANT && minDelayMs == 0) {
+            return;
+        }
+        out.printf("  RetryPolicy: %s%n", delayPolicy.toString().toLowerCase());
+        out.printf("  Minimum Delay: %,d %s%n", minDelayMs, TimeUnit.MILLISECONDS.toString());
+        if (delayPolicy != DelayPolicy.CONSTANT) {
+            out.printf("  Maximum Delay: %,d %s%n", maxDelayMs, TimeUnit.MILLISECONDS.toString());
+        }
     }
 
 


### PR DESCRIPTION
(PR -> https://github.com/scylladb/scylla-tools-java/pull/346)

* add delay options
* back off before retry when OverloadedException is raised

OverloadedException is raised by the underlying cassandra driver if the coordinator replies with an error code of OVERLOADED. this is an indication that the server is overloaded. but in general, this is an intermediate error, so there are chances that the same query could be served later on.

we could do the retry in the driver, but since the cassandra driver is implemented using netty, and the retry handling code is sitting in the netty's io thread. so we cannot just use `Thread.sleep()` in the io thread. it's no-go, just like performing a blocking call in Seastar's reactor thread. also, the retry machinery in the 3.x branch only offers 3 options:

- RETRY: either retry the request on current host, or switch to another
- RETHROW: throw the exception
- IGNORE: return an empty result

the RETRY one does not allow the retry policy to set `RetryDecision` with a configured delay. without a more invasive change, we cannot enable the driver to retry with a backoff when handling OverloadedException.

so, in this change, we add a couple options to allow cassandra-stress to back off when handling OverloadedException. this should increase the scylla's chance of completing a stress test even if the server returns OVERLOAD couple times when serving the queries from client before the configured retries are used up.

a similar change was proposed on cassandra jira 9 years ago, see https://issues.apache.org/jira/browse/CASSANDRA-7821. but it never made its way into the repo.

Refs scylladb/scylladb#15192
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>